### PR TITLE
Basic svg attributes working, "className" correction

### DIFF
--- a/src/coconut/vdom/Html.hx
+++ b/src/coconut/vdom/Html.hx
@@ -101,22 +101,22 @@ private class Svg<Attr:{}> implements NodeType<Attr, Element> {
   public function update(target:Element, old:Attr, nu:Attr)
     Differ.updateObject(target, nu, old, setSvgProp);
 
-  static inline function setSvgProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic)
-    switch name {
-      case 'viewBox' | 'className':
-        if (newVal == null)
-          element.removeAttributeNS(SVG, name);
-        else
-          element.setAttributeNS(SVG, name, newVal);
-      case 'xmlns':
-      case _ if (js.Syntax.code('{0} in {1}', name, element)):
-        Elt.setProp(element, name, newVal, oldVal);
-      default:
-        if (newVal == null)
-          element.removeAttribute(name);
-        else
-          element.setAttribute(name, newVal);
-    }
+	static inline function setSvgProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic) {
+		switch name {
+			case 'xmlns':
+			
+			case 'viewBox' | 'width' | 'height' | 'cx' | 'cy' | 'r': // ,,,				
+				newVal == null ? element.removeAttributeNS(SVG, name) : element.setAttributeNS(SVG, name, newVal);
+			
+			case 'className':
+				newVal == null ? element.removeAttributeNS(SVG, 'class') : element.setAttributeNS(SVG, 'class', newVal);
+
+			case _ if (js.Syntax.code('{0} in {1}', name, element)):
+				Elt.setProp(element, name, newVal, oldVal);
+			default:
+				newVal == null ? element.removeAttribute(name) : element.setAttribute(name, newVal);
+		}
+	}
 
 }
 

--- a/src/coconut/vdom/Html.hx
+++ b/src/coconut/vdom/Html.hx
@@ -100,24 +100,33 @@ private class Svg<Attr:{}> implements NodeType<Attr, Element> {
 
   public function update(target:Element, old:Attr, nu:Attr)
     Differ.updateObject(target, nu, old, setSvgProp);
-
-	static inline function setSvgProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic) {
+  
+  static inline function setSvgProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic) {    
 		switch name {
 			case 'xmlns':
-			
-			case 'viewBox' | 'width' | 'height' | 'cx' | 'cy' | 'r': // ,,,				
-				newVal == null ? element.removeAttributeNS(SVG, name) : element.setAttributeNS(SVG, name, newVal);
-			
+			case 'viewBox' | 'width' | 'height' | 'cx' | 'cy' | 'r': // ,,,
+				if (newVal == null) {
+					element.removeAttributeNS(SVG, name)
+				} else {
+					element.setAttributeNS(SVG, name, newVal)
+				};
 			case 'className':
-				newVal == null ? element.removeAttributeNS(SVG, 'class') : element.setAttributeNS(SVG, 'class', newVal);
+				if (newVal == null) {
+					element.removeAttributeNS(SVG, 'class')
+				} else {
+					element.setAttributeNS(SVG, 'class', newVal)
+				};
 
 			case _ if (js.Syntax.code('{0} in {1}', name, element)):
 				Elt.setProp(element, name, newVal, oldVal);
 			default:
-				newVal == null ? element.removeAttribute(name) : element.setAttribute(name, newVal);
+				if (newVal == null) {
+					element.removeAttribute(name)
+				} else {
+					element.setAttribute(name, newVal)
+				};
 		}
 	}
-
 }
 
 private class Elt<Attr:{}> implements NodeType<Attr, Element> {

--- a/src/coconut/vdom/Html.hx
+++ b/src/coconut/vdom/Html.hx
@@ -101,33 +101,29 @@ private class Svg<Attr:{}> implements NodeType<Attr, Element> {
   public function update(target:Element, old:Attr, nu:Attr)
     Differ.updateObject(target, nu, old, setSvgProp);
   
-  static inline function setSvgProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic) {    
+	static inline function setSvgProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic) {    
 		switch name {
 			case 'xmlns':
 			case 'viewBox' | 'width' | 'height' | 'cx' | 'cy' | 'r': // ,,,
-				if (newVal == null) {
+				if (newVal == null) 
 					element.removeAttributeNS(SVG, name)
-				} else {
-					element.setAttributeNS(SVG, name, newVal)
-				};
+				else 
+					element.setAttributeNS(SVG, name, newVal);
 			case 'className':
-				if (newVal == null) {
+				if (newVal == null) 
 					element.removeAttributeNS(SVG, 'class')
-				} else {
-					element.setAttributeNS(SVG, 'class', newVal)
-				};
+				else 
+					element.setAttributeNS(SVG, 'class', newVal);
 
 			case _ if (js.Syntax.code('{0} in {1}', name, element)):
 				Elt.setProp(element, name, newVal, oldVal);
 			default:
-				if (newVal == null) {
+				if (newVal == null) 
 					element.removeAttribute(name)
-				} else {
-					element.setAttribute(name, newVal)
-				};
-		}
+				else
+					element.setAttribute(name, newVal);
+    }   
 	}
-}
 
 private class Elt<Attr:{}> implements NodeType<Attr, Element> {
 

--- a/src/coconut/vdom/Html.hx
+++ b/src/coconut/vdom/Html.hx
@@ -149,7 +149,7 @@ private class Elt<Attr:{}> implements NodeType<Attr, Element> {
     Reflect.setField(target, name, if (newVal == null) null else newVal);
 
   static public inline function setProp(element:Element, name:String, newVal:Dynamic, ?oldVal:Dynamic)
-    switch name {
+    switch name { 
       case 'style':
         Differ.updateObject(element.style, newVal, oldVal, setStyle);
       case 'attributes':


### PR DESCRIPTION
Get basic svg attributes working (wievBox, width, height etc.). Correct that "class" attribute wrongly is named "className" in the generated output.